### PR TITLE
FEAT: Add tags for models that used DataDreamer trainers

### DIFF
--- a/src/trainers/_train_hf_base.py
+++ b/src/trainers/_train_hf_base.py
@@ -1094,6 +1094,13 @@ class _TrainHFBase(DataDreamerTrainer):
             **self.kwargs,
             **classification_kwargs,
         )
+
+        # Optionally add tags if the user has the appropriate transformers
+        # version. That way the tag will be pushed automatically even if the
+        # users do not call `trainer.push_to_hub()` but e.g. `model.push_to_hub()`
+        if hasattr(model, "add_model_tags"):
+            model.add_model_tags(self._trainer_tags)
+
         from .train_hf_classifier import TrainHFClassifier
         from .train_setfit_classifier import TrainSetFitClassifier
 

--- a/src/trainers/trainer.py
+++ b/src/trainers/trainer.py
@@ -76,6 +76,8 @@ def _monkey_patch_TrainerState__post_init__():
 
 
 class Trainer(ABC):
+    _trainer_tags = ["datadreamer"]
+
     def __init__(  # noqa: C901
         self,
         name: str,


### PR DESCRIPTION
Hi @AjayP13 👋 

First of all congratulations for releasing this great library ! 
I would like to introduce a feature here: model tagging - this makes it possible to add tags in models that are fine-tuned with DataDreamer so that you could filter them on HF hub easily, e.g.: https://huggingface.co/models?other=trl for TRL tag! 

Let me know if you want me to extensively test this feature by pushing some dummy models on the Hub ! 

Thanks again !