### PR TITLE
Fix kwargs error from LLM endpoint in rag_prompt.py

### DIFF
--- a/src/steps/prompt/rag_prompt.py
+++ b/src/steps/prompt/rag_prompt.py
@@ -140,8 +140,9 @@ class RAGPrompt(_PromptBase, SuperStep):
                 )
 
         # Generate
+        run_args = {k:v for k,v in args.items() if k not in ["retriever", "k"]}
         return self._run_prompts(
-            args=args,
+            args=run_args,
             prompts=partial(
                 create_prompts,
                 llm,


### PR DESCRIPTION
Fixed RAGPrompt error where retriever and k were being submitted to the LLM endpoint, causing runtime error.

This should resolve the issue reported below:

#34 